### PR TITLE
use ccng v2 api for fetching handles

### DIFF
--- a/lib/base/catalog_manager_v2.rb
+++ b/lib/base/catalog_manager_v2.rb
@@ -22,23 +22,18 @@ module VCAP
         missing_opts = required_opts.select {|o| !opts.has_key? o}
         raise ArgumentError, "Missing options: #{missing_opts.join(', ')}" unless missing_opts.empty?
 
-        @gateway_name         = opts[:gateway_name]
-        @cld_ctrl_uri         = opts[:cloud_controller_uri]
-        @service_list_uri     = "/v2/services?inline-relations-depth=2"
-        @offering_uri         = "/v2/services"
-        @service_plans_uri    = "/v2/service_plans"
+        @gateway_name          = opts[:gateway_name]
+        @cld_ctrl_uri          = opts[:cloud_controller_uri]
+        @service_list_uri      = "/v2/services?inline-relations-depth=2"
+        @offering_uri          = "/v2/services"
+        @service_plans_uri     = "/v2/service_plans"
+        @service_instances_uri = "/v2/service_instances"
+        @service_bindings_uri  = "/v2/service_bindings"
+        @handle_guid         = {}
 
         @logger               = opts[:logger]
 
         @service_auth_tokens  = opts[:service_auth_tokens]
-
-        # Used ONLY for invoking list/update handles v1 api
-        # TODO: remove this
-        gateway_token_hdr = VCAP::Services::Api::GATEWAY_TOKEN_HEADER
-        @cc_req_hdrs_for_v1_api = {
-          'Content-Type'    => 'application/json',
-          gateway_token_hdr => opts[:token]
-        }
 
         refresh_client_auth_token if !@test_mode # use for specs only
 
@@ -483,44 +478,124 @@ module VCAP
         return false
       end
 
-      ######## Handles processing #########
-      #TODO: This will still use V1 api for first iteration. The V2 api call is more involved as it requires
-      # drilling down multiple levels into the V2 ccdb schema.
+      # fetch all handles for instances and bindings for caching on service gateway
+      # this function allows user gateway to fetch all the instance and binding handles
+      # from cloud_controller_ng with a certain service label
+      def fetch_handles_from_cc(service_label, after_fetch_callback)
+        @logger.info("CCNG Catalog Manager:(v2) Fetching all handles from cloud controller...")
+        return unless after_fetch_callback
+
+        @fetching_handles = true
+
+        handles = fetch_all_instance_handles_from_cc
+        binding_handles = fetch_all_binding_handles_from_cc(handles)
+        handles.concat(binding_handles)
+        @logger.info("CCNG Catalog Manager:(v2) Successfully fetched all handles from cloud controller...")
+
+        handles = VCAP::Services::Api::ListHandlesResponse.decode(Yajl::Encoder.encode({:handles => handles}))
+        after_fetch_callback.call(handles) if after_fetch_callback
+      ensure
+        @fetching_handles = false
+      end
+
+      def fetch_all_instance_handles_from_cc
+        @logger.info("CCNG Catalog Manager:(v2) Fetching all service instance handles from cloud controller: #{@cld_ctrl_uri}#{@service_instance_uri}")
+        instance_handle_list = []
+
+        registered_services = load_registered_services_from_cc
+        registered_services.select{|service| @service_auth_tokens.has_key?(service)}
+
+        registered_services.each_value do |registered_service|
+          registered_service['service']['plans'].each_value do |plan_details|
+            plan_guid = plan_details["guid"]
+            instance_handles_query = "?q=service_plan_guid:#{plan_guid}"
+            instance_handles = fetch_instance_handles_from_cc(instance_handles_query)
+            instance_handle_list.concat(instance_handles) if instance_handles
+          end
+        end
+        @logger.info("CCNG Catalog Manager:(v2) Successfully fetched all service instance handles from cloud controller: #{@cld_ctrl_uri}#{@service_instance_uri}")
+        instance_handle_list
+      end
+
+      def fetch_all_binding_handles_from_cc(instance_handles)
+        @logger.info("CCNG Catalog Manager:(v2) Fetching all service binding handles from cloud controller: #{@cld_ctrl_uri}#{@service_instance_uri}")
+        binding_handles_list = []
+
+        # currently we will fetch each binding handle according to instance handle
+        # TODO: add a query parameter in ccng v2 to support query from service name to binding handle;
+        instance_handles.each do |instance_handle|
+          service_instance_guid = instance_handle[:service_id]
+          binding_handles_query = "?q=service_instance_guid:#{@handle_guid[service_instance_guid]}"
+          binding_handles = fetch_binding_handles_from_cc(binding_handles_query)
+          binding_handles_list.concat(binding_handles) if binding_handles
+        end
+        @logger.info("CCNG Catalog Manager:(v2) Successfully fetched all service binding handles from cloud controller: #{@cld_ctrl_uri}#{@service_instance_uri}")
+        binding_handles_list
+      end
+
+      # fetch instance handles from cloud_controller_ng
+      # this function allows users to get a dedicated set of instance handles
+      # from cloud_controller_ng using a customized query for /v2/service_binding api
+      #
+      # @param string instance_handles_query
+      def fetch_instance_handles_from_cc(instance_handles_query)
+        @logger.info("CCNG Catalog Manager:(v2) Fetching service instance handles from cloud controller: #{@cld_ctrl_uri}#{@service_instance_uri}#{instance_handles_query}")
+
+        instance_handles = []
+        # currently we are fetching all the service instances from different plans;
+        # TODO: add a query parameter in ccng v2 to support a query from service name to instance handle;
+        service_instance_uri = "#{@service_instances_uri}#{instance_handles_query}"
+
+        perform_multiple_page_get(service_instance_uri, "service instance handles") do |resources|
+          instance_info = resources['entity']
+
+          instance_handle = {
+            :service_id    => instance_info['credentials']['name'],
+            :configuration => instance_info['gateway_data'],
+            :credentials   => instance_info['credentials'],
+          }
+          instance_handles << instance_handle
+          @handle_guid[instance_handle[:service_id]] = resources['metadata']['guid']
+        end
+        instance_handles
+      rescue => e
+        @logger.error("CCNG Catalog Manager:(v2) Error decoding reply from gateway: #{e.backtrace}")
+      end
+
+      # fetch binding handles from cloud_controller_ng
+      # this function allows users to get a dedicated set of binding handles
+      # from cloud_controller_ng using a customized query for /v2/service_binding api
+      #
+      # @param string binding_handles_query
+      def fetch_binding_handles_from_cc(binding_handles_query)
+        @logger.info("CCNG Catalog Manager:(v2) Fetching service binding handles from cloud controller: #{@cld_ctrl_uri}#{@service_bindings_uri}#{binding_handles_query}")
+
+        binding_handles = []
+        binding_handles_uri = "#{@service_bindings_uri}#{binding_handles_query}"
+
+        perform_multiple_page_get(binding_handles_uri, "service binding handles") do |resources|
+          binding_info = resources['entity']
+
+          binding_handle = {
+            :service_id    => binding_info['gateway_name'],
+            :configuration => binding_info['gateway_data'],
+            :credentials   => binding_info['credentials'],
+          }
+          binding_handles << binding_handle
+          @handle_guid[binding_handle[:service_id]] = resources['metadata']['guid']
+        end
+        binding_handles
+      rescue => e
+        @logger.error("CCNG Catalog Manager:(v2) Error decoding reply from gateway: #{e}")
+      end
 
       def get_handles_uri(service_label)
         "/services/v1/offerings/#{service_label}/handles"
       end
 
-      def fetch_handles_from_cc(service_label, after_fetch_callback)
-        return if @fetching_handles
-
-        handles_uri = get_handles_uri(service_label)
-
-        @logger.info("CCNG Catalog Manager:(v1) Fetching handles from cloud controller: #{handles_uri}")
-        @fetching_handles = true
-
-        cc_http_request(:uri => handles_uri, :method => "get", :head => @cc_req_hdrs_for_v1_api) do |http|
-          @fetching_handles = false
-
-          if http.error.empty?
-            if http.response_header.status == 200
-              @logger.info("CCNG Catalog Manager:(v1) Successfully fetched handles")
-
-              begin
-                resp = VCAP::Services::Api::ListHandlesResponse.decode(http.response)
-                after_fetch_callback.call(resp) if after_fetch_callback
-              rescue => e
-                @logger.error("CCNG Catalog Manager:(v1) Error decoding reply from gateway: #{e}")
-              end
-            else
-              @logger.error("CCNG Catalog Manager:(v1) Failed fetching handles, status=#{http.response_header.status}")
-            end
-          else
-            @logger.error("CCNG Catalog Manager:(v1) Failed fetching handles: #{http.error}")
-          end
-        end
-      end
-
+      # update handles in ccdb
+      # TODO update the handles using the code in v2 api after ccng added a new api endpoint for update handle
+      #      tracking: https://www.pivotaltracker.com/s/projects/166935/stories/45086405
       def update_handle_in_cc(service_label, handle, on_success_callback, on_failure_callback)
         @logger.debug("CCNG Catalog Manager:(v1) Update service handle: #{handle.inspect}")
         if not handle


### PR DESCRIPTION
passed manual tests;
1. create an instance without binding and another instance with binding;
2. restarted the service gateway and it is able to fetch the handles correctly;

yeti pending because of build-pack failures, will update when the yeti was fully run.
