### PR TITLE
 V1 support for plan descriptions 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem "dm-sqlite-adapter"
   gem "cf-uaa-lib"
   gem 'eventmachine', :git => 'git://github.com/cloudfoundry/eventmachine.git', :branch => 'release-0.12.11-cf'
-  gem 'vcap_common', :require => ['vcap/common', 'vcap/component'], :git => 'git://github.com/cloudfoundry/vcap-common.git', :ref => '68d86f57fb'
+  gem 'vcap_common', :require => ['vcap/common', 'vcap/component'], :git => 'git://github.com/cloudfoundry/vcap-common.git', :ref => '06812223'
   gem 'vcap_logging', :require => ['vcap/logging'], :git => 'git://github.com/cloudfoundry/common.git', :ref => 'b96ec1192d'
   gem 'warden-client', :require => ['warden/client'], :git => 'git://github.com/cloudfoundry/warden.git', :ref => 'fe6cb51'
   gem 'warden-protocol', :require => ['warden/protocol'], :git => 'git://github.com/cloudfoundry/warden.git', :ref => 'fe6cb51'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GIT
 
 GIT
   remote: git://github.com/cloudfoundry/vcap-common.git
-  revision: 68d86f57fb82eb44489ace026b6c95102f050c86
-  ref: 68d86f57fb
+  revision: 06812223684d7b8385e828841be9737a98a4bdee
+  ref: 06812223
   specs:
     vcap_common (2.0.10)
       em-http-request (~> 1.0.0.beta3, < 1.0.0.beta4)
@@ -134,7 +134,7 @@ GEM
     eventmachine_httpserver (0.2.1)
     fastercsv (1.5.5)
     http_parser.rb (0.5.3)
-    httpclient (2.3.2)
+    httpclient (2.3.3)
     json (1.4.6)
     json_pure (1.7.5)
     macaddr (1.6.1)
@@ -142,7 +142,7 @@ GEM
     membrane (0.0.2)
     mime-types (1.21)
     multi_json (1.0.4)
-    multipart-post (1.1.5)
+    multipart-post (1.2.0)
     nats (0.4.24)
       daemons (>= 1.1.5)
       eventmachine (>= 0.12.10)

--- a/lib/base/catalog_manager_v1.rb
+++ b/lib/base/catalog_manager_v1.rb
@@ -67,12 +67,13 @@ module VCAP
       end
 
       def generate_cc_advertise_offering_request(svc, active = true)
-        plans = svc["plans"] if svc["plans"].is_a?(Array)
-        if svc["plans"].is_a?(Hash)
-          plans = []
-          svc["plans"].keys.each { |k| plans << k.to_s }
+        plans = svc["plans"]
+        plan_descriptions = nil
+        if plans.is_a?(Hash)
+          describe = Proc.new { |p| { p.to_s => plans[p][:description] } }
+          plan_descriptions = plans.keys.map(&describe).reduce(&:merge)
+          plans = plans.keys.map(&:to_s)
         end
-
         VCAP::Services::Api::ServiceOfferingRequest.new({
           :label => svc["label"],
           :description => svc["description"],
@@ -84,6 +85,7 @@ module VCAP
           :plans => plans,
           :cf_plan_id => svc["cf_plan_id"],
           :default_plan => svc["default_plan"],
+          :plan_descriptions => plan_descriptions,
 
           :tags => svc["tags"] || [],
 


### PR DESCRIPTION
$ git shortlog 68d86f57fb82eb44489ace026b6c95102f050c86..06812223684d7b
Nicholas Kushmerick (1):
      Add optional plan_descriptions to a V1 service offering
