### PR TITLE
Fix travis failure caused by incorrect namespace for logger level

### DIFF
--- a/spec/helper/external_services_gateway_spec_helper.rb
+++ b/spec/helper/external_services_gateway_spec_helper.rb
@@ -49,7 +49,7 @@ class ExternalServicesGatewayHelper
 
   def make_logger
     logger = Logger.new(STDOUT)
-    logger.level = DEBUG
+    logger.level = Logger::DEBUG
     logger
   end
 


### PR DESCRIPTION
Change-Id: I591d397d9d0ed1c12f282279397e173d61501586
