### PR TITLE
Extends handle configuration

### DIFF
--- a/lib/base/provisioner.rb
+++ b/lib/base/provisioner.rb
@@ -463,7 +463,7 @@ class VCAP::Services::Base::Provisioner < VCAP::Services::Base::Base
               # credentials is not necessary in cache
               prov_req.credentials = nil
               credential = response.credentials
-              svc = {:configuration => prov_req.dup, :service_id => credential['name'], :credentials => credential}
+              svc = {:configuration => request.extract.dup, :service_id => credential['name'], :credentials => credential}
               @logger.debug("Provisioned: #{svc.inspect}")
               @prov_svcs[svc[:service_id]] = svc
               blk.call(success(svc))


### PR DESCRIPTION
The origin of the change is CCNG provides api to query apps inlined with service bindings. But I find that service binding does not have enough information including service type. And I think we should be able to tell, at least, what type of service the binding belongs by its handle. So it comes this change.

Currently service handle configuration only saves plan & version information.  
But the request from CC actually contains much more information.
non-ng request: 
{:label=>"rabbitmq-2.4", :name=>"rabbitmq-42029", :email=>"foobar@vmware.com", :plan=>"free", :version=>"2.4"}
ng request:
{:label=>"rabbitmq-2.8", :name=>"rabbitmq-3d441", :email=>"sre@vmware.com", :plan=>"100", :plan_option=>{}, :version=>"2.8", :provider=>"core", :space_guid=>"78234de5-d5d0-4b61-a58f-f07cbf1a6fea", :organization_guid=>"1d48f31a-3d4e-4792-b688-2cd93a4841ba"}

And this change store the CC request as the provision & binding configuration.
And I see oauth gateway already did this way...
