### PR TITLE
Don't lose service instances after gateway/broker restart

### DIFF
--- a/lib/base/service_message.rb
+++ b/lib/base/service_message.rb
@@ -78,6 +78,7 @@ module VCAP::Services::Internal
     optional :service_bindings_url, String
     optional :space_url,            String
     optional :service_plan_url,     String
+    optional :type,                 String
     optional :dashboard_url,        String
   end
 


### PR DESCRIPTION
After a gateway/broker restart it is unable to rebuild its catalog from the cloud controller.
As a consequence you will not be able to bind to existing services. 
Services which where bind before the restart keep functioning as normal.

The problem could be traced back to the [addition of a type field for service instances](https://github.com/cloudfoundry/cloud_controller_ng/commit/a142df242fbb2ef2108704fde4caec0fd8b2fd83).
This `type` field is not expected by the catalog manager and as a result it decides to skip the instance.
